### PR TITLE
Updating for latest spotify shas  and installer

### DIFF
--- a/recipes/spotify.rb
+++ b/recipes/spotify.rb
@@ -18,7 +18,7 @@
 
 remote_file "#{Chef::Config[:file_cache_path]}/SpotifyInstaller.zip" do
   source 'http://download.spotify.com/SpotifyInstaller.zip'
-  checksum 'c5fa2d1d6389cd4680bbcc2476a3c015e195ed7e4909ef68e2cd36722b61ce1d'
+  checksum '76d5d23a3c9860ca76b489614a9936885fee8017e972803bd98a212ddb4e3598'
   notifies :run, "execute[unzip-spotify]", :immediately
 end
 

--- a/recipes/spotify.rb
+++ b/recipes/spotify.rb
@@ -23,6 +23,14 @@ remote_file "#{Chef::Config[:file_cache_path]}/SpotifyInstaller.zip" do
 end
 
 execute "unzip-spotify" do
-  command "unzip #{Chef::Config[:file_cache_path]}/SpotifyInstaller.zip -d /Applications"
+  command "unzip #{Chef::Config[:file_cache_path]}/SpotifyInstaller.zip -d #{Chef::Config[:file_cache_path]}"
   action :nothing
+  notifies :run, "execute[install-spotify]", :immediately
+end
+
+execute "install-spotify" do
+  cwd Chef::Config[:file_cache_path]
+  command "open 'Install Spotify.app'"
+  action :nothing
+  not_if do ::File.exists?('/Applications/Spotify.app') end
 end


### PR DESCRIPTION
Update Spotify checksum and run installer, rather than copying installer to /Application.
